### PR TITLE
add corpus option to tatm data

### DIFF
--- a/src/tatm/data/data.py
+++ b/src/tatm/data/data.py
@@ -81,7 +81,10 @@ class TatmTextData(TatmData):
             corpus: Corpus to load. Defaults to None.
         """
         self.dataset = datasets.load_dataset(
-            self.metadata.dataset_path, name=corpus, streaming=True
+            self.metadata.dataset_path,
+            name=corpus,
+            streaming=True,
+            trust_remote_code=True,
         )[split]
 
     def __iter__(self):

--- a/tests/data/corpus_data/corpus_data.py
+++ b/tests/data/corpus_data/corpus_data.py
@@ -1,0 +1,83 @@
+import datasets
+
+primary_lines = [
+    "This is the first primary sentence.",
+    "This is the second primary sentence.",
+    "This is the third primary sentence.",
+    "This is the fourth primary sentence.",
+    "This is the fifth primary sentence.",
+]
+
+secondary_lines = [
+    "This is a test sentence.",
+    "Another test sentence.",
+    "Yet another test sentence.",
+    "This is the fourth test sentence.",
+    "Finally, this is the last test sentence.",
+]
+
+
+class CorpusDataConfig(datasets.BuilderConfig):
+    """BuilderConfig for CorpusData."""
+
+    def __init__(self, *args, subsets, **kwargs):
+        super(CorpusDataConfig, self).__init__(**kwargs)
+        self.subsets = subsets
+
+
+class CorpusData(datasets.GeneratorBasedBuilder):
+    """Corpus dataset for testing tatm corpus functionality."""
+
+    DEFAULT_CONFIG_NAME = "default"
+
+    BUILDER_CONFIGS = [
+        CorpusDataConfig(
+            name="default",
+            version=datasets.Version("1.0.0"),
+            description="full dataset",
+            subsets=["primary", "secondary"],
+        ),
+        CorpusDataConfig(
+            name="primary",
+            version=datasets.Version("1.0.0"),
+            description="Primary dataset",
+            subsets=["primary"],
+        ),
+        CorpusDataConfig(
+            name="secondary",
+            version=datasets.Version("1.0.0"),
+            description="Secondary dataset",
+            subsets=["secondary"],
+        ),
+    ]
+
+    def _info(self):
+        return datasets.DatasetInfo(
+            description="A dataset for testing tatm corpus functionality.",
+            features=datasets.Features({"text": datasets.Value("string")}),
+            supervised_keys=None,
+            homepage="http://example.com",
+            citation="Citation information.",
+        )
+
+    def _split_generators(self, dl_manager):
+
+        return [
+            datasets.SplitGenerator(
+                name=datasets.Split.TRAIN,
+                gen_kwargs={"subsets": self.config.subsets},
+            ),
+        ]
+
+    def _generate_examples(self, subsets):
+        """Yields examples."""
+        key = 0
+        for subset in subsets:
+            if subset == "primary":
+                for _, line in enumerate(primary_lines):
+                    yield key, {"text": line}
+                    key += 1
+            elif subset == "secondary":
+                for _, line in enumerate(secondary_lines):
+                    yield key, {"text": line}
+                    key += 1

--- a/tests/data/corpus_data/create_corpus_data.py
+++ b/tests/data/corpus_data/create_corpus_data.py
@@ -1,0 +1,21 @@
+import tatm.data.metadata as metadata
+
+
+def main():
+
+    # Create metadata for dataset
+    dataset_metadata = metadata.TatmDataMetadata(
+        name="test_corpus_data",
+        dataset_path="tests/data/corpus_data",
+        description="A test corpus data set intended for use in testing.",
+        date_downloaded="2021-01-01",
+        download_source="http://example.com",
+        data_content="text",
+        content_field="text",
+        corpuses=["primary", "secondary"],
+    )
+    dataset_metadata.to_yaml("metadata.yaml")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/corpus_data/metadata.yaml
+++ b/tests/data/corpus_data/metadata.yaml
@@ -1,0 +1,10 @@
+content_field: text
+corpuses:
+- primary
+- secondary
+data_content: text
+dataset_path: tests/data/corpus_data
+date_downloaded: '2021-01-01'
+description: A test corpus data set intended for use in testing.
+download_source: http://example.com
+name: test_corpus_data

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -5,3 +5,27 @@ def test_text_json_dataset_load():
     dataset = get_data("tests/data/json_data")
     first_item = next(iter(dataset))
     assert first_item["text"] == "hello world"
+
+
+def test_corpus_data_load():
+    for corpus in ["primary", "secondary"]:
+        dataset = get_data(f"tests/data/corpus_data:{corpus}")
+        item = 0
+        for i in dataset:
+            if item == 0:
+                if corpus == "primary":
+                    assert i["text"] == "This is the first primary sentence."
+                else:
+                    assert i["text"] == "This is a test sentence."
+            item += 1
+        assert item == 5
+
+
+def test_corpus_full_data_load():
+    dataset = get_data("tests/data/corpus_data")
+    item = 0
+    for i in dataset:
+        if item == 0:
+            assert i["text"] == "This is the first primary sentence."
+        item += 1
+    assert item == 10

--- a/tests/tokenizer/test_engine.py
+++ b/tests/tokenizer/test_engine.py
@@ -145,3 +145,35 @@ def test_ray_run_in_debug_mode(tmp_path):
 
     engine_result = np.memmap(str(tmp_path / "test_0.bin"), dtype="uint16", mode="r")
     assert np.array_equal(engine_result[0 : len(tokenized)], tokenized)
+
+
+def test_ray_run_corpus(tmp_path):
+    """Integration test for the Engine class with Ray."""
+    # Initialize Ray
+    ray.init(num_cpus=4, ignore_reinit_error=True)
+    dataset_id = "tests/data/corpus_data:secondary"
+    dataset = tatm.data.get_data(dataset_id)
+    tokenizer = tokenizers.Tokenizer.from_pretrained("t5-base")
+
+    # Create an instance of the Engine
+    engine = TokenizationEngine([dataset_id], "t5-base", str(tmp_path), "test")
+
+    # Run the engine with some input
+    engine.run_with_ray(num_workers=1)
+    time.sleep(1)  # Wait for the workers to finish
+    gc.collect()
+
+    first_example = next(iter(dataset))
+    tokenized = tokenizer.encode(first_example[dataset.metadata.content_field]).ids
+
+    actors = ray.util.state.list_actors()
+    assert len(actors) == 3  # Ensure only 1 worker is created
+    assert (
+        len([x for x in actors if x.state == "ALIVE"]) == 0
+    )  # Ensure all actors are cleaned up
+
+    # Clean up ray
+    ray.shutdown()
+
+    engine_result = np.memmap(str(tmp_path / "test_0.bin"), dtype="uint16", mode="r")
+    assert np.array_equal(engine_result[0 : len(tokenized)], tokenized)


### PR DESCRIPTION
Allow specification of a corpus when loading raw data w/ tatm.

Format will be
<data_id>:<corpus_name>

Will be used to support tokenization of subsets of red pajama, other data