### PR TITLE
Fix issue with doc deployment not running

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -42,4 +42,4 @@ jobs:
               uses: peaceiris/actions-gh-pages@v3
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
-                  publish_dir: ./docs/build/html
+                  publish_dir: ./docs/_build/html


### PR DESCRIPTION
Need to update the if statement for running the docs build, looks like `head_ref` isn't available on pushes