### PR TITLE
Fix memory-mapped arrays when context length does not divide number of tokens

### DIFF
--- a/src/tatm/data/datasets.py
+++ b/src/tatm/data/datasets.py
@@ -99,7 +99,10 @@ class TokenMemMapArray:
     def __len__(self):
         """Get the number of tokens in the array."""
         if self.chunked:
-            return self.num_tokens // self.context_length
+            chunks = self.num_tokens // self.context_length
+            if self.num_tokens % self.context_length != 0:
+                chunks += 1
+            return chunks
         else:
             return self.num_tokens
 

--- a/tests/data/test_memmap_dataset.py
+++ b/tests/data/test_memmap_dataset.py
@@ -28,6 +28,9 @@ def test_memmap_array(sample_dataset):
     assert len(memmap_array) == 10
     assert np.all(memmap_array[0] == np.arange(100))
 
+    memmap_array_not_divisible = TokenMemMapArray(test_file, 9, "uint16", True)
+    assert len(memmap_array_not_divisible) == 112
+
 
 def test_memmap_dataset(sample_dataset):
     dataset = TatmMemmapDataset(


### PR DESCRIPTION
Closes #53 