### PR TITLE
Iss62 link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 `tatm` (**T**ransformer **A**ssistive **T**estbed **M**odule) is a Python library that provides a set of tools to assist in the development of transformer-based (and other architecture) models for research within the Kempner institute. It will provide an interface for accessing and manipulating data, training models, and evaluating models. The library is designed to be modular and extensible, allowing for easy integration of new models, datasets, and training frameworks.
 
+## Documentation
+
+[![Documentation Status](https://readthedocs.org/projects/tatm/badge/?version=latest)](https://tatm.readthedocs.io/en/latest/?badge=latest)
+
+- [Stable Version Documentation](https://tatm.readthedocs.io/en/latest/index.html)
+   - [Getting Started](https://tatm.readthedocs.io/en/latest/getting_started.html)
+
+- [Nightly Version Documentaiton](https://kempnerinstitute.github.io/tatm/)
+   - [Getting Started](https://kempnerinstitute.github.io/tatm/getting_started.html)
+
 ## Installation
 
 ### Requirements

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
    - [Getting Started](https://tatm.readthedocs.io/en/latest/getting_started.html)
    - [Example Working with a Text Dataset](https://tatm.readthedocs.io/en/latest/text_dataset.html)
 
-- [Nightly Version Documentaiton](https://kempnerinstitute.github.io/tatm/)
+- [Nightly Version Documentation](https://kempnerinstitute.github.io/tatm/)
    - [Getting Started](https://kempnerinstitute.github.io/tatm/getting_started.html)
    - [Example Working with a Text Dataset](https://kempnerinstitute.github.io/tatm/text_dataset.html)
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@
 
 ## Documentation
 
-[![Documentation Status](https://readthedocs.org/projects/tatm/badge/?version=latest)](https://tatm.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/tatm/badge/?version=latest)](https://tatm.readthedocs.io/en/latest/?badge=latest)x
 
 - [Stable Version Documentation](https://tatm.readthedocs.io/en/latest/index.html)
    - [Getting Started](https://tatm.readthedocs.io/en/latest/getting_started.html)
+   - [Getting Started](https://tatm.readthedocs.io/en/latest/text_dataset.html)
 
 - [Nightly Version Documentaiton](https://kempnerinstitute.github.io/tatm/)
    - [Getting Started](https://kempnerinstitute.github.io/tatm/getting_started.html)
+   - [Example Working with a Text Dataset](https://kempnerinstitute.github.io/tatm/text_dataset.html)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Documentation
 
-[![Documentation Status](https://readthedocs.org/projects/tatm/badge/?version=latest)](https://tatm.readthedocs.io/en/latest/?badge=latest)x
+[![Documentation Status](https://readthedocs.org/projects/tatm/badge/?version=latest)](https://tatm.readthedocs.io/en/latest/?badge=latest)
 
 - [Stable Version Documentation](https://tatm.readthedocs.io/en/latest/index.html)
    - [Getting Started](https://tatm.readthedocs.io/en/latest/getting_started.html)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - [Stable Version Documentation](https://tatm.readthedocs.io/en/latest/index.html)
    - [Getting Started](https://tatm.readthedocs.io/en/latest/getting_started.html)
-   - [Getting Started](https://tatm.readthedocs.io/en/latest/text_dataset.html)
+   - [Example Working with a Text Dataset](https://tatm.readthedocs.io/en/latest/text_dataset.html)
 
 - [Nightly Version Documentaiton](https://kempnerinstitute.github.io/tatm/)
    - [Getting Started](https://kempnerinstitute.github.io/tatm/getting_started.html)


### PR DESCRIPTION
Linking to docs from readme. Note that the stable version links won't work/will report failure until we release our first stable version