### PR TITLE
Format output tokens for torch

### DIFF
--- a/src/tatm/utils.py
+++ b/src/tatm/utils.py
@@ -19,3 +19,7 @@ class TatmOptionEnum(str, Enum):
     @classmethod
     def has_value(cls, value):
         return any(value == item.value for item in cls)
+
+    @classmethod
+    def values(cls):
+        return [item.value for item in cls]

--- a/tests/data/test_metadata_beckend.py
+++ b/tests/data/test_metadata_beckend.py
@@ -76,7 +76,7 @@ def test_get_tokenized_from_metadata_store(json_metadata_store, monkeypatch):
     reset_backend()
     _, config_path = json_metadata_store
     monkeypatch.setenv("TATM_BASE_CONFIG", str(config_path))
-    dataset = get_dataset("tokenized", context_length=100)
+    dataset = get_dataset("tokenized", context_length=100, token_output_format="numpy")
     assert len(dataset) == 100
     assert dataset.vocab_size == 32100
     assert np.all(dataset[0]["token_ids"] == np.arange(100))


### PR DESCRIPTION
resolves #75 
Adds optional input to memmap datasets to specify output format, supports output as numpy arrays or torch tensors (default). SHould be extensible to support JAX arrays in the future