### PR TITLE
create index based validation splits

### DIFF
--- a/src/tatm/data/datasets.py
+++ b/src/tatm/data/datasets.py
@@ -92,8 +92,7 @@ class TatmDataset(ABC):
         """Determine an index to split the dataset into training and validation sets.
         Splits the dataset into a training and validation set based on the split size where the last
         indices are used for validation.
-        Sets the index that is the first index of the validation set. THe logic of how to handle
-        that index is left to subclasses to implement in their __len__ and __getitem__ method.
+        Sets the index that is the first index of the validation set. 
 
         Args:
             split_size: Either the ratio of the validation set to the whole data or

--- a/src/tatm/data/datasets.py
+++ b/src/tatm/data/datasets.py
@@ -56,6 +56,27 @@ class TatmDataset(ABC):
             split_size = math.ceil(len(self) * split_size)
         self._split_index = len(self) - split_size
 
+    def set_split(self, split: Optional[SplitType] = None):
+        """Set the split of the data that the __len__ and __getitem__ will operate on. If called without an argument, __len__ and __getitem__ will use the
+        unsplit dataset.
+
+        Args:
+            split: The split of the data that the __len__ and __getitem__ will operate on. If None, __len__ and __getitem__ will use the
+                unsplit dataset. Defaults to None.
+        """
+        if split is not None:
+            if not SplitType.has_value(split):
+                raise ValueError(
+                    f"Invalid split type {split}. Valid values are {SplitType.values()}."
+                )
+            if self._split_index is None:
+                raise ValueError(
+                    "No current index to split the dataset has been set. Please call create_split prior to setting a split."
+                )
+            self.split = SplitType(split)
+        else:
+            self.split = None
+
 
 def get_dataset(metadata: Union[str, TatmDataMetadata], **kwargs) -> TatmDataset:
     """Get the dataset object from the metadata.
@@ -352,30 +373,11 @@ class TatmMemmapDataset(TatmDataset):
 
     def create_split(self, split_size: Union[float, int] = 0.1):
         current_split = self.split
-        self.set_split(None)  # Reset the split so that the whole dataset length is used to determine the split
+        self.set_split(
+            None
+        )  # Reset the split so that the whole dataset length is used to determine the split
         super().create_split(split_size)
         self.set_split(current_split)
-
-    def set_split(self, split: Optional[SplitType] = None):
-        """Set the split of the data that the __len__ and __getitem__ will operate on. If called without an argument, __len__ and __getitem__ will use the
-        unsplit dataset.
-
-        Args:
-            split: The split of the data that the __len__ and __getitem__ will operate on. If None, __len__ and __getitem__ will use the
-                unsplit dataset. Defaults to None.
-        """
-        if split is not None:
-            if not SplitType.has_value(split):
-                raise ValueError(
-                    f"Invalid split type {split}. Valid values are {SplitType.values()}."
-                )
-            if self._split_index is None:
-                raise ValueError(
-                    "No current index to split the dataset has been set. Please call create_split prior to setting a split."
-                )
-            self.split = SplitType(split)
-        else:
-            self.split = None
 
 
 def _get_document_ids(tokens: np.ndarray, eos_token: int = 1) -> np.ndarray:

--- a/src/tatm/data/datasets.py
+++ b/src/tatm/data/datasets.py
@@ -320,9 +320,7 @@ class TatmMemmapDataset(TatmDataset):
         elif self.split == SplitType.TRAIN:
             return self._split_index
         elif self.split == SplitType.VALIDATION:
-            return (
-                self._num_samples() - self._split_index
-            )
+            return self._num_samples() - self._split_index
 
     def __getitem__(self, idx: int):
         """Get the token at the given index."""
@@ -330,7 +328,7 @@ class TatmMemmapDataset(TatmDataset):
             idx = len(self) + idx
             if idx < 0:
                 raise IndexError("Index out of bounds.")
-        
+
         if idx >= len(self):
             raise IndexError("Index out of bounds.")
 

--- a/src/tatm/data/datasets.py
+++ b/src/tatm/data/datasets.py
@@ -92,7 +92,7 @@ class TatmDataset(ABC):
         """Determine an index to split the dataset into training and validation sets.
         Splits the dataset into a training and validation set based on the split size where the last
         indices are used for validation.
-        Sets the index that is the first index of the validation set. 
+        Sets the index that is the first index of the validation set.
 
         Args:
             split_size: Either the ratio of the validation set to the whole data or

--- a/src/tatm/data/datasets.py
+++ b/src/tatm/data/datasets.py
@@ -309,15 +309,19 @@ class TatmMemmapDataset(TatmDataset):
             self.file_list.append((start_idx, i))
             start_idx += len(i)
 
+    def _num_samples(self):
+        """Get the number of examples in the dataset, regardless of split."""
+        return self.file_list[-1][0] + len(self.file_list[-1][1])
+
     def __len__(self):
-        """Get the number of examples in the dataset."""
+        """Get the number of examples in the current split of the dataset."""
         if self.split is None:
-            return self.file_list[-1][0] + len(self.file_list[-1][1])
+            return self._num_samples()
         elif self.split == SplitType.TRAIN:
             return self._split_index
         elif self.split == SplitType.VALIDATION:
             return (
-                self.file_list[-1][0] + len(self.file_list[-1][1]) - self._split_index
+                self._num_samples() - self._split_index
             )
 
     def __getitem__(self, idx: int):
@@ -326,6 +330,9 @@ class TatmMemmapDataset(TatmDataset):
             idx = len(self) + idx
             if idx < 0:
                 raise IndexError("Index out of bounds.")
+        
+        if idx >= len(self):
+            raise IndexError("Index out of bounds.")
 
         if self.split == SplitType.VALIDATION:
             idx += self._split_index

--- a/src/tatm/data/datasets.py
+++ b/src/tatm/data/datasets.py
@@ -352,7 +352,7 @@ class TatmMemmapDataset(TatmDataset):
 
     def create_split(self, split_size: Union[float, int] = 0.1):
         current_split = self.split
-        self.set_split()  # Reset the split so that the whole dataset length is used to determine the split
+        self.set_split(None)  # Reset the split so that the whole dataset length is used to determine the split
         super().create_split(split_size)
         self.set_split(current_split)
 

--- a/tests/data/test_memmap_dataset.py
+++ b/tests/data/test_memmap_dataset.py
@@ -216,7 +216,7 @@ class TestValidationSplits:
             assert len(dataset) == 80
         else:
             assert len(dataset) == 100
-    
+
     @pytest.mark.parametrize("split_size", [20, 0.2])
     def test_index_bounds(self, sample_dataset, split_size):
         dataset = TatmMemmapDataset(
@@ -233,4 +233,3 @@ class TestValidationSplits:
             _ = dataset[80]
         with pytest.raises(IndexError):
             _ = dataset[-81]
-

--- a/tests/data/test_memmap_dataset.py
+++ b/tests/data/test_memmap_dataset.py
@@ -168,3 +168,51 @@ def test_dataloader_integration(sample_dataset):
 def test_handle_nonexistent_path():
     with pytest.raises(FileNotFoundError):
         _ = get_dataset("nonexistent_path", context_length=100)
+
+
+class TestValidationSplits:
+
+    def test_split_index_determination(self, sample_dataset):
+        dataset = TatmMemmapDataset(
+            str(sample_dataset[0] / sample_dataset[1]), 100, "uint16"
+        )
+        dataset.create_split(20)
+        print(dataset._split_index)
+        assert dataset._split_index == 80
+        dataset.create_split(0.2)
+        assert dataset._split_index == 80
+
+    @pytest.mark.parametrize("split_size", [20, 0.2])
+    @pytest.mark.parametrize("split", ["train", "validation"])
+    def test_split_indexing(self, sample_dataset, split, split_size):
+        dataset = TatmMemmapDataset(
+            str(sample_dataset[0] / sample_dataset[1]), 100, "uint16"
+        )
+        if split == "train":
+            test_record = dataset[0]
+        elif split == "validation":
+            test_record = dataset[80]
+        dataset.create_split(split_size)
+        dataset.set_split(split)
+        if split == "train":
+            assert len(dataset) == 80
+        elif split == "validation":
+            assert len(dataset) == 20
+        assert torch.all(test_record["token_ids"] == dataset[0]["token_ids"])
+
+    @pytest.mark.parametrize("split_size", [20, 0.2])
+    @pytest.mark.parametrize("split", [None, "train", "validation"])
+    def test_split_indexing_at_instantiation(self, sample_dataset, split, split_size):
+        dataset = TatmMemmapDataset(
+            str(sample_dataset[0] / sample_dataset[1]),
+            100,
+            "uint16",
+            val_split_size=split_size,
+            split=split,
+        )
+        if split == "validation":
+            assert len(dataset) == 20
+        elif split == "train":
+            assert len(dataset) == 80
+        else:
+            assert len(dataset) == 100

--- a/tests/data/test_memmap_dataset.py
+++ b/tests/data/test_memmap_dataset.py
@@ -216,3 +216,21 @@ class TestValidationSplits:
             assert len(dataset) == 80
         else:
             assert len(dataset) == 100
+    
+    @pytest.mark.parametrize("split_size", [20, 0.2])
+    def test_index_bounds(self, sample_dataset, split_size):
+        dataset = TatmMemmapDataset(
+            str(sample_dataset[0] / sample_dataset[1]), 100, "uint16"
+        )
+        dataset.create_split(split_size)
+        dataset.set_split("validation")
+        with pytest.raises(IndexError):
+            _ = dataset[20]
+        with pytest.raises(IndexError):
+            _ = dataset[-21]
+        dataset.set_split("train")
+        with pytest.raises(IndexError):
+            _ = dataset[80]
+        with pytest.raises(IndexError):
+            _ = dataset[-81]
+


### PR DESCRIPTION
Closes #114 

Implements the ability to set index based training and validation splits in TatmMemmapDatasets. Splits can be specified using either observation counts or split ratios.