### PR TITLE
Remove upper bounds from package dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -5324,4 +5324,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "9ebe1cf42bac38d4d10da3c02c97e9a607916d91e0a5e70bffd840f7105002bb"
+content-hash = "664b5ea951e268ebefd6637f1658919397ab350d82dc44c849a4f5b28b04a8d8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 
@@ -16,20 +16,20 @@ classifiers = [
 "License :: OSI Approved :: MIT License",
 "Operating System :: OS Independent"
 ]
-requires-python = ">=3.10,<4"
+requires-python = ">=3.10"
 dependencies = [
-    "click (>=8.1.7,<9.0.0)",
-    "datasets (>=3.0.1,<4.0.0)",
+    "click >=8.1.7",
+    "datasets >=3.0.1",
     "tokenizers>=0.20.0",
-    "ray[default] (>=2.34.0,<3.0.0)",
-    "pyyaml (>=6.0.2,<7.0.0)",
-    "omegaconf (>=2.3.0,<3.0.0)",
-    "torch (>=2.4.1,<3.0.0)",
-    "requests (>=2.32.3,<3.0.0)",
+    "ray[default]>=2.34.0",
+    "pyyaml>=6.0.2",
+    "omegaconf>=2.3.0",
+    "torch>=2.4.1",
+    "requests>=2.32.3",
     "aiohttp>=3.10.11",
-    "pillow (>=11.0.0,<12.0.0)",
+    "pillow>=11.0.0",
     "openmetadata-ingestion==1.5.12",
-    "zstandard (>=0.23.0,<0.24.0)"
+    "zstandard>=0.23.0"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,27 @@ dependencies = [
     "zstandard>=0.23.0"
 ]
 
+[dependency-groups]
+lint = [
+    "black>=24.8.0",
+    "flake8>=7.1.1",
+    "isort>=5.13.2",
+]
+test = [
+    "pytest>=8.3.2",
+    "pytest-cov>=5.0.0",
+]
+docs = [
+    "sphinx>=8.0.2",
+    "myst-parser>=4.0.0",
+    "sphinx_rtd_theme>=3.0.1",
+]
+dev = [
+    {include-group = "lint"},
+    {include-group = "test"},
+    {include-group = "docs"}
+]
+
 
 [project.scripts]
 tatm = "tatm:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ classifiers = [
 "License :: OSI Approved :: MIT License",
 "Operating System :: OS Independent"
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.10,<4"
 dependencies = [
-    "click >=8.1.7",
-    "datasets >=3.0.1",
+    "click>=8.1.7",
+    "datasets>=3.0.1",
     "tokenizers>=0.20.0",
     "ray[default]>=2.34.0",
     "pyyaml>=6.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,34 +45,34 @@ packages = [{include = "tatm", from = "src"}]
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-black = "^24.8.0"
-flake8 = "^7.1.1"
-pytest = "^8.3.2"
-pytest-cov = "^5.0.0"
-sphinx = "^8.0.2"
-myst-parser = "^4.0.0"
-isort = "^5.13.2"
-sphinx_rtd_theme = "^3.0.1"
+black = ">=24.8.0"
+flake8 = ">=7.1.1"
+pytest = ">=8.3.2"
+pytest-cov = ">=5.0.0"
+sphinx = ">=8.0.2"
+myst-parser = ">=4.0.0"
+isort = ">=5.13.2"
+sphinx_rtd_theme = ">=3.0.1"
 
 
 [tool.poetry.group.test]
 optional = true
 
 [tool.poetry.group.test.dependencies]
-black = "^24.8.0"
-flake8 = "^7.1.1"
-pytest = "^8.3.2"
-pytest-cov = "^5.0.0"
-isort = "^5.13.2"
+black = ">=24.8.0"
+flake8 = ">=7.1.1"
+pytest = ">=8.3.2"
+pytest-cov = ">=5.0.0"
+isort = ">=5.13.2"
 
 
 [tool.poetry.group.docs]
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-sphinx = "^8.0.2"
-myst-parser = "^4.0.0"
-sphinx_rtd_theme = "^3.0.1"
+sphinx = ">=8.0.2"
+myst-parser = ">=4.0.0"
+sphinx_rtd_theme = ">=3.0.1"
 
 
 [tool.isort]


### PR DESCRIPTION
Closes #135 
Closes KEM-10

This PR removes upper bounds on the package dependencies in TATM, following the guidance in [this article](https://iscinumpy.dev/post/bound-version-constraints). The upper bounds (which are frequently default in poetry) are overly restrictive and make it hard for package managers to resolve dependencies for any downstream projects that import TATM.

In addition, I have also added dependency groups following [PEP 735](https://peps.python.org/pep-0735/). This doesn't impact the poetry build, but allows us to switch to other package managers like uv which do not use poetry's custom format. Poetry doesn't yet look at this field, but it is a planned enhancement, after which we can remove the poetry specific fields.